### PR TITLE
Integrate Zig with Next.js

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,10 @@ Zig can be used to build **Node.js native modules** (`.node` files) using **N-AP
 - Write performance-critical parts of Next.js backend in Zig.
 - Use Zig as an alternative to C/C++ in Node.js native addons.
 
+## 5. Using Zig for Serverless Functions in Next.js
+- Next.js API routes can call Zig-compiled binaries for performance-heavy tasks.
+- Deploy Zig-based microservices that integrate with Next.js via APIs.
+
 ## Conclusion
 - **Fully building Next.js in Zig?** Not feasible.
 - **Using Zig within Next.js?** Definitely possible for WASM, backend APIs, and native modules.

--- a/pages/api/zig-backend.js
+++ b/pages/api/zig-backend.js
@@ -1,7 +1,11 @@
 import fetch from 'node-fetch';
 
 export default async function handler(req, res) {
-  const response = await fetch('http://localhost:8080/api/zig-endpoint');
-  const data = await response.json();
-  res.status(200).json(data);
+  if (req.method === 'GET' && req.url === '/api/zig-backend') {
+    const response = await fetch('http://localhost:8080/api/zig-endpoint');
+    const data = await response.json();
+    res.status(200).json(data);
+  } else {
+    res.status(404).json({ message: 'Not Found' });
+  }
 }

--- a/public/zig-wasm/zig_module.wasm
+++ b/public/zig-wasm/zig_module.wasm
@@ -6,3 +6,12 @@
     i32.add)
   (memory $memory (export "memory") 1)
   (data (i32.const 0) "Hello, Zig WASM!"))
+
+(module
+  (type $t1 (func (param i32) (result i32)))
+  (func $multiply_by_two (export "multiply_by_two") (type $t1) (param $p1 i32) (result i32)
+    get_local $p1
+    i32.const 2
+    i32.mul)
+  (memory $memory (export "memory") 1)
+  (data (i32.const 0) "Hello, Zig WASM!"))


### PR DESCRIPTION
Integrate Zig with Next.js by adding new functionalities and updating existing ones.

* **Backend APIs**: Update `pages/api/zig-backend.js` to handle GET requests to the new API route `/api/zig-backend` and return a JSON response.
* **WebAssembly**: Add a new WebAssembly module `zig_module.wasm` in `public/zig-wasm/zig_module.wasm` with a function `multiply_by_two` for handling WebAssembly requests.
* **Documentation**: Update `README.md` to include a new section on using Zig for serverless functions in Next.js and explain the new Zig integration.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/sisovin/zig_nextjs_usernrole_lesson08/pull/1?shareId=23e985f1-905a-4275-99a3-f040c7c34350).