### PR TITLE
Update Zig server and API route

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,24 @@ Zig can be used to build **Node.js native modules** (`.node` files) using **N-AP
 - Next.js API routes can call Zig-compiled binaries for performance-heavy tasks.
 - Deploy Zig-based microservices that integrate with Next.js via APIs.
 
+## Running the Zig-based HTTP Server
+To run the Zig-based HTTP server, follow these steps:
+1. Build the Zig server:
+   ```sh
+   zig build-exe api/zig-server.zig
+   ```
+2. Run the server:
+   ```sh
+   ./zig-server
+   ```
+3. The server will be listening on `http://localhost:3001`.
+
+## Example API Route
+The example API route `/api/zig-endpoint` can be accessed at:
+```sh
+http://localhost:3001/api/zig-endpoint
+```
+
 ## Conclusion
 - **Fully building Next.js in Zig?** Not feasible.
 - **Using Zig within Next.js?** Definitely possible for WASM, backend APIs, and native modules.


### PR DESCRIPTION
Update the Zig-based HTTP server and README.

* **api/zig-server.zig**
  - Change server address to listen on `localhost:3001` instead of `localhost:3000`.
  - Add a new route `/api/zig-endpoint` to handle API requests.
  - Add `sendJsonResponse` function to handle JSON responses for the new API route.

* **README.md**
  - Add a section explaining how to run the Zig-based HTTP server.
  - Update the example API route to match the new route `/api/zig-endpoint`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/sisovin/zig_nextjs_usernrole_lesson08/pull/2?shareId=47706420-1886-4819-8d2f-96fd5b22076e).